### PR TITLE
v1 of Results Pagination

### DIFF
--- a/Code/integration-tests/QueryParser.test.js
+++ b/Code/integration-tests/QueryParser.test.js
@@ -193,12 +193,12 @@ describe("QueryParser Class Tests", () => {
          * This one is a simple 2-val BVA for the max num of rows returned
          */
         test.each([
-            2, /* has over 10 */
-            3 /* has exactly 10 */
-        ])("Accounts with more than 10 clients only return 10 rows", async (acctID) => {
+            2, /* has over 15 */
+            3 /* has exactly 15 */
+        ])("Accounts with more than 10 clients only return 15 rows", async (acctID) => {
             let results = await qp.getAllClients(acctID);
 
-            await expect(results[0].length).toBe(10);
+            await expect(results[0].length).toBe(15);
         });
 
         test.each([

--- a/Code/public/js/resultsScript.js
+++ b/Code/public/js/resultsScript.js
@@ -7,6 +7,7 @@ const nextButton = document.getElementById("nextButton");
 const oldURL = new URL(window.location.href);
 const searchString = new URLSearchParams(oldURL.search);
 let currentPage = parseInt(searchString.get("page")) || 1;
+currentPage = currentPage < 1 ? 1 : currentPage;
 
 
 if (clientRows.length < 15){

--- a/Code/public/js/resultsScript.js
+++ b/Code/public/js/resultsScript.js
@@ -2,6 +2,21 @@ const backButton = document.getElementById("goBackButton");
 const selectButton = document.getElementById("selectButton");
 const clientRows = document.querySelectorAll("#clientRow");
 const clientTableBody = document.getElementById("clientTableBody");
+const prevButton = document.getElementById("prevButton");
+const nextButton = document.getElementById("nextButton");
+const oldURL = new URL(window.location.href);
+const searchString = new URLSearchParams(oldURL.search);
+let currentPage = parseInt(searchString.get("page")) || 1;
+
+
+if (clientRows.length < 15){
+    nextButton.disabled = true;
+    nextButton.style.cursor = "not-allowed";
+}
+if (currentPage <= 1){
+    prevButton.disabled = true;
+    prevButton.style.cursor = "not-allowed";
+}
 
 // Event Listener for Back Button
 backButton.addEventListener("click", () => history.back());
@@ -63,3 +78,25 @@ selectButton.addEventListener("click", () => {
     })  
     .catch(error => console.log("Error: ", error))
 });
+
+/**
+ * Event Listener for Previous Button
+ */
+prevButton.addEventListener("click", () => {
+    if (currentPage > 1){
+        currentPage--;
+        searchString.set("page", currentPage.toString());
+        oldURL.search = searchString.toString();
+        window.location.replace(oldURL);
+    }
+});
+
+nextButton.addEventListener("click", ()=>{
+    if (clientRows.length === 15){
+        currentPage++;
+        searchString.set("page", currentPage.toString());
+        oldURL.search = searchString.toString();
+        window.location.replace(oldURL);
+    }
+})
+

--- a/Code/sql/StaffClient_pop.sql
+++ b/Code/sql/StaffClient_pop.sql
@@ -49,4 +49,15 @@ INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemove
 INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 2, 'Counselor 1', '2025-02-01', null);
 INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 3, 'Counselor 1', '2023-05-15', '2024-10-17');
 INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 5, 'Counselor 1', '2025-03-12', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 9, 'Counselor 1', '2023-12-10', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 10, 'Counselor 1', '2023-12-10', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 11, 'Counselor 1', '2023-12-10', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 12, 'Counselor 1', '2023-12-10', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 13, 'Counselor 1', '2023-12-10', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 14, 'Counselor 1', '2023-12-10', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (3, 15, 'Counselor 1', '2023-12-10', null);
 
+
+-- Extra for Staff 2
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (2, 5, 'Support Staff 2', '2024-05-13', null);
+INSERT INTO HCAR.StaffClient (staffID, clientID, title, dateAssigned, dateRemoved) VALUES (2, 17, 'Support Staff 2', '2023-11-24', null);

--- a/Code/views/results.ejs
+++ b/Code/views/results.ejs
@@ -67,8 +67,8 @@
     <button id="goBackButton" class="dimHover footerButton">Go Back</button>
 
     <div id="pageChanger">
-        <button type="button" disabled="disabled">← Previous</button>
-        <button type="button">Next →</button>
+        <button type="button" id="prevButton">← Previous</button>
+        <button type="button" id="nextButton">Next →</button>
     </div>
     <!-- Probably going to need JavaScript to make this button work nicely -->
     <button id="selectButton" class="dimHover footerButton">Select</button>

--- a/Code/views/search.ejs
+++ b/Code/views/search.ejs
@@ -6,7 +6,7 @@
     </head>
     <body class="hcar-body">
         <%-include("header")-%>
-        <form method="post" action="/results" id="searchForm">
+        <form method="get" action="/results" id="searchForm">
         <div id="searchContainer">
                 <div id="firstNameFilter">
                     <label for="firstName">First Name</label> <br />


### PR DESCRIPTION
* both /results and /results/all now use GET with the additional page query
* security fix: no blind trusting of filters in getAllFilteredClients in QP
* Some front end JS to disable erroneous behavior on results, such as trying to change pages when impossible or manually setting illegal page number in GET request